### PR TITLE
Changes to make the Dockerfile portable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,3 @@ logs
 Dockerfile
 reports
 README.md
-gauge-reports


### PR DESCRIPTION
1. Copy the local source directory to the image
 This is done as npm install generates platform specific
binaries. In earlier versions the sample project only
had one dependency. However projects will have many
dependencies
2. Rename gauge-user to gauge
3. Add environment flags to skip features that will
not be used inside a container.
4. Install gauge via npm as a gauge user
5. Add local npm directory to path

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>